### PR TITLE
Add empin APIs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,7 +6,7 @@ module.exports = function(grunt) {
 				separator: ';'
 			},
 			mergeJs: {
-				src: ['bower_components/amcl/js/DBIG.js','bower_components/amcl/js/BIG.js', 'bower_components/amcl/js/FP.js', 'bower_components/amcl/js/ROM.js', 'bower_components/amcl/js/HASH.js', 'bower_components/amcl/js/RAND.js', 'bower_components/amcl/js/AES.js', 'bower_components/amcl/js/GPM.js', 'bower_components/amcl/js/ECP.js', 'bower_components/amcl/js/FP2.js', 'bower_components/amcl/js/ECP2.js', 'bower_components/amcl/js/FP4.js', 'bower_components/amcl/js/FP12.js', 'bower_components/amcl/js/PAIR.js', 'bower_components/amcl/js/MPIN.js', 'bower_components/amcl/js/MPINAuth.js', 'lib/mpin.js'],
+				src: ['bower_components/amcl/js/DBIG.js','bower_components/amcl/js/BIG.js', 'bower_components/amcl/js/FP.js', 'bower_components/amcl/js/ROM.js', 'bower_components/amcl/js/HASH.js', 'bower_components/amcl/js/RAND.js', 'bower_components/amcl/js/AES.js', 'bower_components/amcl/js/GPM.js', 'bower_components/amcl/js/UTILS.js', 'bower_components/amcl/js/ECP.js', 'bower_components/amcl/js/FP2.js', 'bower_components/amcl/js/ECP2.js', 'bower_components/amcl/js/FP4.js', 'bower_components/amcl/js/FP12.js', 'bower_components/amcl/js/PAIR.js', 'bower_components/amcl/js/MPIN.js', 'bower_components/amcl/js/MPINAuth.js', 'bower_components/amcl/js/eMPINAuth.js', 'lib/mpin.js'],
 				dest: './dist/mpinjs.js'
 			}
 		},

--- a/lib/mpin.js
+++ b/lib/mpin.js
@@ -33,6 +33,10 @@ var mpinjs = (function () {
   Errors.identityNotAuthorized = {code: 10, type: "IDENTITY_NOT_AUTHORIZED"};
   Errors.incorrectAccessNumber = {code: 11, type: "INCORRECT_ACCESS_NUMBER"};
 
+  Errors.missingActivationCode = {code: 12, type: "MISSING_ACTIVATION_CODE"};
+  Errors.invalidActivationCode = {code: 13, type: "INVALID_ACTIVATION_CODE"};
+  Errors.maxAttemptsCountOver = {code: 14, type: "MAX_ATTEMPTS_COUNT_OVER"};
+
   States.invalid = "INVALID";
   States.start = "STARTED";
   States.active = "ACTIVATED";
@@ -85,7 +89,7 @@ var mpinjs = (function () {
     return this;
   };
 
-  Mpin.prototype.startRegistration = function (userId, cb) {
+  Mpin.prototype.startRegistration = function (userId, cb, useEMpin) {
     var _reqData = {}, self = this, _userState;
     if (!userId) {
       return cb ? cb(Errors.missingUserId, null) : {error: 1};
@@ -95,13 +99,19 @@ var mpinjs = (function () {
       return cb({code: Errors.missingParams.code, type: Errors.missingParams.type, message: "Missing registerURL"}, null);
     }
 
+
+
     //invalid
     _userState = this.getUser(userId, "state");
     if (_userState !== States.invalid) {
       return cb(Errors.wrongFlow, null);
     }
 
-    _reqData.url = this.generateUrl("register");
+    if (useEMpin) {
+      _reqData.url = this.generateUrl("eMpinRegister");
+    } else {
+      _reqData.url = this.generateUrl("register");
+    }
     _reqData.type = "PUT";
     _reqData.data = {
       userId: userId,
@@ -113,23 +123,45 @@ var mpinjs = (function () {
     }
 
     this.request(_reqData, function (err, data) {
+
       if (err) {
+        if (err.status === 403) {
+          return cb && cb(Errors.invalidUserId, null);
+        }
         return cb(err, null);
       }
 
       self.addToUser(userId, {regOTT: data.regOTT, mpinId: data.mpinId, state: States.start});
 
-      //force activate
-      if (data.active) {
-        self.addToUser(userId, {state: States.active});
+      if (useEMpin) {
+        self.addToUser(userId, {cs1: data.clientSecretShare, csParams: data.params, state: States.active});
+
+        if (data.active) {
+          self.addToUser(userId, {activationSkip: true, activationCode: data.activationCode});
+        } else {
+          self.addToUser(userId, {activationSkip: false, activationCode: data.activationCode});
+        }
+      } else {
+        //force activate
+        if (data.active) {
+          self.addToUser(userId, {state: States.active});
+        }
       }
 
       cb && cb(null, true);
     });
   };
 
+  Mpin.prototype.getActivationCodeAdhoc = function(userId) {
+    if (Users[userId].activationSkip) {
+      return Users[userId].activationCode;
+    } else {
+      return false;
+    }
+  };
+
   //request cs1 + cs2
-  Mpin.prototype.confirmRegistration = function (userId, cb) {
+  Mpin.prototype.confirmRegistration = function (userId, cb, useEMpin) {
     var _cs1Url = "", self = this, _userState;
     if (!userId) {
       return cb ? cb(Errors.missingUserId, null) : Errors.missingUserId;
@@ -149,6 +181,44 @@ var mpinjs = (function () {
     if (Users[userId].csHex) {
       return cb(null, true);
     }
+
+    if (useEMpin) {
+      this.getClientSecretOneStep(userId, cb);
+    } else {
+      this.getClientSecretTwoStep(userId, cb);
+    }
+  };
+
+  Mpin.prototype.getClientSecretOneStep = function(userId, cb) {
+    var _cs2Url = "", self = this;
+    _cs2Url = self.settings.certivoxURL + "clientSecret?" + Users[userId].csParams;
+
+    //req cs2
+    self.request({url: _cs2Url}, function (err, cs2Data) {
+      var csHex;
+      if (err) {
+        if (err.status == 408) {
+          return cb(Errors.timeoutFinish, null);
+        } else {
+          return cb(Errors.wrongFlow, null);
+        }
+      }
+
+      if (!cs2Data.clientSecret) {
+        return cb(Errors.wrongFlow, null);
+      }
+
+      self.addToUser(userId, {cs2: cs2Data.clientSecret});
+      csHex = MPINAuth.addShares(cs2Data.clientSecret, Users[userId].cs1);
+
+      self.addToUser(userId, {csHex: csHex});
+
+      cb(null, true);
+    });
+  };
+
+  Mpin.prototype.getClientSecretTwoStep = function(userId, cb) {
+    var _cs1Url = "", self = this;
 
     _cs1Url = this.generateUrl('signature', {userId: userId});
     //req cs1
@@ -177,7 +247,51 @@ var mpinjs = (function () {
     });
   };
 
-  Mpin.prototype.finishRegistration = function (userId, pin) {
+  Mpin.prototype.activationCodeVerify = function(userId, activationCode, cb) {
+    if (!userId) {
+      return cb && cb(Errors.missingUserId, null);
+    } else if (!activationCode) {
+      return cb && cb(Errors.missingActivationCode, null);
+    }
+
+    var secretKey = this.calcSecretKey(Users[userId].mpinId, Users[userId].csHex, activationCode, cb);
+    if (!secretKey) {
+        cb && cb(Errors.wrongFlow, true);
+    }
+    var _verifyData = {};
+    _verifyData.url = this.generateUrl("activation_check");
+    _verifyData.type = 'POST';
+    _verifyData.data = eMpinAuth.activationCheck(Users[userId].mpinId, secretKey);
+
+    this.request(_verifyData, function(verifyError, verifyData) {
+      if (verifyError) {
+        if (verifyError.status === 403) {
+          cb && cb(Errors.invalidActivationCode, null);
+        } else if (verifyError.status === 410) {
+          cb && cb(Errors.maxAttemptsCountOver, null);
+        } else {
+          cb && cb(verifyError, null);
+        }
+        return;
+      }
+
+      if (verifyData.result) {
+        cb && cb(null, true);
+      } else {
+        cb && cb(Errors.invalidActivationCode, null);
+      }
+    });
+  };
+
+  Mpin.prototype.calcSecretKey = function(mpinId, clientSecret, activationCode, cb) {
+    if (!mpinId || !clientSecret | !activationCode) {
+      return '';
+    }
+    var secretKey = eMpinAuth.calcClientSecretWithActivationCode(mpinId, clientSecret, activationCode, false);
+    return secretKey;
+  };
+
+  Mpin.prototype.finishRegistration = function (userId, pin, activationCode, useEMpin) {
     var _user, token;
 
     if (!userId) {
@@ -190,15 +304,21 @@ var mpinjs = (function () {
       return Errors.wrongFlow;
     }
 
-    if (isNaN(pin)) {
-      pin = this.toHash(pin);
-    }
 
-    token = MPINAuth.calculateMPinToken(Users[userId].mpinId, pin, Users[userId].csHex);
+    if (useEMpin) {
+      var secretKey = this.calcSecretKey(Users[userId].mpinId, Users[userId].csHex, activationCode);
+      token = eMpinAuth.calcClientSecretWithStringPin(Users[userId].mpinId, secretKey, pin, true);
+      delete Users[userId].activationCode;
+    } else {
+      if (isNaN(pin)) {
+        pin = this.toHash(pin);
+      }
+      token = MPINAuth.calculateMPinToken(Users[userId].mpinId, pin, Users[userId].csHex);
+    }
     delete Users[userId].csHex;
 
     this.addToUser(userId, {token: token, state: States.register});
-
+ 
     return true;
   };
 
@@ -334,7 +454,7 @@ var mpinjs = (function () {
   };
 
 
-  Mpin.prototype.finishAuthentication = function (userId, pin, cb) {
+  Mpin.prototype.finishAuthentication = function (userId, pin, cb, useEMpin) {
     var _userState;
 
     //registered
@@ -345,7 +465,16 @@ var mpinjs = (function () {
       return cb({code: Errors.wrongFlow.code, type: Errors.wrongFlow.type, message: "Need to call startAuthentication method before this."}, null);
     }
 
-    this._passRequests({userId: userId, pin: pin}, cb);
+    var opts = {
+      userId: userId,
+      pin: pin
+    };
+
+    if (useEMpin) {
+      this._eMpinPassRequests(opts, cb);
+    } else {
+      this._passRequests(opts, cb);
+    }
   };
 
   Mpin.prototype.finishAuthenticationOtp = function (userId, pin, cb) {
@@ -402,6 +531,27 @@ var mpinjs = (function () {
       cb(null, data);
     });
 
+  };
+
+  Mpin.prototype._eMpinPassRequests = function(opts, cb) {
+    var userId = opts.userId;
+    var self = this;
+    var pin = opts.pin;
+
+    var _authData = this.getEMpinAuthData(userId, pin);
+    self.request(_authData, function(authError, authData) {
+      if (authError) {
+        if (authError.status === 403) {
+          cb && cb(Errors.wrongPin, null);
+        } else if (authError.status === 410) {
+          cb && cb(Errors.maxAttemptsCountOver, null);
+        } else {
+          cb && cb(Errors.wrongPin, null);
+        }
+      } else {
+        cb(null, authData);
+      }
+    });
   };
 
   Mpin.prototype._passRequests = function (opts, cb) {
@@ -543,6 +693,19 @@ var mpinjs = (function () {
     return MPINAuth.pass1Request(_auth.mpin, _auth.token, _auth.timePermit, pin, _auth.date, null);
   };
 
+  Mpin.prototype.getEMpinAuthData = function (userId, pin) {
+    var _authData = {};
+    var timePermitHex = Users[userId].timePermitHex;
+    var tokenHex = Users[userId].token;
+    var client_current_time = eMpinAuth.getTime().toString(16);
+
+    _authData.url = this.generateUrl("eMpinAuth");
+    _authData.type = "POST";
+    _authData.data = eMpinAuth.authenticate(Users[userId].mpinId, client_current_time, tokenHex, timePermitHex, pin);
+
+    return _authData;
+  };
+
   Mpin.prototype.fromHex = function (strData) {
     if (!strData || strData.length % 2 != 0)
       return '';
@@ -590,8 +753,9 @@ var mpinjs = (function () {
     });
   };
 
-  Mpin.prototype.waitForMobileAuth = function (timeoutSeconds, requestSeconds, cb) {
+  Mpin.prototype.waitForMobileAuth = function (timeoutSeconds, requestSeconds, cb, useEMpin) {
     var self = this, _reqData = {};
+    useEMpin = useEMpin || false;
     if (!this.webOTT) {
       return cb({code: Errors.wrongFlow.code, type: Errors.wrongFlow.type, message: "Need to call getAccessNumber method before this."}, null);
     } else if (!timeoutSeconds) {
@@ -615,16 +779,23 @@ var mpinjs = (function () {
           self.timeoutPeriod -= _requestPeriod;
 
           self.intervalID2 = setTimeout(function () {
-            self.waitForMobileAuth.call(self, timeoutSeconds, requestSeconds, cb);
+            self.waitForMobileAuth.call(self, timeoutSeconds, requestSeconds, cb, useEMpin);
           }, _requestPeriod);
           return;
         } else if (self.timeoutPeriod <= 0) {
           delete self.timeoutPeriod;
           cb && cb(Errors.timeoutFinish, null);
           return;
+        } else if (err.status === 404) {
+          cb && cb(Errors.wrongFlow, null);
+          return;
         }
       } else {
-        self._authenticate({mpinResponse: data}, cb);
+        if (useEMpin) {
+          cb && cb(null, {mpinResponse: data});
+        } else {
+          self._authenticate({mpinResponse: data}, cb);
+        }
       }
     });
   };
@@ -651,10 +822,16 @@ var mpinjs = (function () {
         url = this.settings.registerURL + "/";
         url += Users[options.userId].mpinId;
         break;
+      case "eMpinRegister":
+        url = this.settings.eMpinActivationURL;
+        break;
       case "signature":
         url = this.settings.signatureURL + "/";
         url += Users[options.userId].mpinId;
         url += "?regOTT=" + Users[options.userId].regOTT;
+        break;
+      case "activation_check":
+        url = this.settings.mpinAuthServerURL + '/eMpinActivationVerify';
         break;
       case "permit1":
         url = this.settings.timePermitsURL + "/";
@@ -675,6 +852,9 @@ var mpinjs = (function () {
         break;
       case "pass2":
         url = this.settings.mpinAuthServerURL + "/pass2";
+        break;
+      case "eMpinAuth":
+        url = this.settings.mpinAuthServerURL + '/eMpinAuthentication';
         break;
       case "auth":
         url = this.settings.authenticateURL;

--- a/lib/mpin.js
+++ b/lib/mpin.js
@@ -763,6 +763,8 @@ var mpinjs = (function () {
 
     //If mpinId has changed, we need to delete the object withthe previous one
     if (Users[userId].mpinId && userProps.mpinId && Users[userId].mpinId != userProps.mpinId) {
+      // delete information bound to mpinId
+      delete Users[userId].timePermitCache;
       this.deleteData(userId);
     }
 

--- a/test/empin.js
+++ b/test/empin.js
@@ -1,0 +1,442 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+//if browser
+if (typeof require !== 'undefined') {
+  var expect = require('chai').expect;
+  var sinon = require('sinon');
+  var sinonChai = require('sinon-chai');
+  var mpinjs = require('../index');
+  var empin_inits = require("./empin_inits");
+}
+var eMpinErrors, eMpinTestData, eMpinTestLocalstorage, eMpinTestLocalStorage2;
+
+eMpinErrors = empin_inits.Errors;
+eMpinMPINAuth = empin_inits.MPINAuth;
+eMpinMPIN = empin_inits.MPIN;
+eMpinTestData = empin_inits.testData;
+eMpinTestLocalstorage = empin_inits.testLocalStorage;
+eMpinTestLocalStorage2 = empin_inits.testLocalStorage2;
+
+
+describe("# eMpin startRegistration.", function () {
+  var mpin;
+
+  beforeEach(function() {
+    mpin = new mpinjs({server: eMpinTestData.serverUrl});
+    sinon.stub(mpin, "getData", function () {
+      return eMpinTestLocalstorage;
+    });
+    sinon.stub(mpin, "storeData");
+    //mock for init method
+    stub = sinon.stub(mpin, 'request');
+    stub.onCall(0).yields(null, eMpinTestData.clientSettings);
+  });
+
+  afterEach(function() {
+    mpin.request.restore();
+    mpin.restore();
+  });
+
+  it("should return error type " + eMpinErrors.invalidUserId + " call with invalid userId", function (done) {
+    var userId = "invalidUserId";
+
+    stub.onCall(1).yields({status: 403});
+    mpin.init(function (err, data) {
+      mpin.makeNewUser(userId);
+      mpin.startRegistration(userId, function (err1, data1) {
+        expect(err1).to.deep.equal({code: 1, type: eMpinErrors.invalidUserId});
+        done();
+      }, true);
+    });
+  });
+
+
+  it("should return OK.", function (done) {
+    var userId = "test@user.id";
+
+    stub.onCall(1).yields(null, eMpinTestData.mpin);//mpinId
+    mpin.init(function (err, data) {
+      mpin.makeNewUser(userId);
+      mpin.startRegistration(userId, function (err1, data1) {
+        expect(data).to.exist;
+        done();
+      }, true);
+    });
+  });
+});
+
+describe("# eMpin getActivationCodeAdhoc.", function () {
+  var mpin;
+
+  beforeEach(function() {
+    mpin = new mpinjs({server: eMpinTestData.serverUrl});
+    sinon.stub(mpin, "getData", function () {
+      return eMpinTestLocalstorage;
+    });
+    sinon.stub(mpin, "storeData");
+    //mock for init method
+    stub = sinon.stub(mpin, 'request');
+    stub.onCall(0).yields(null, eMpinTestData.clientSettings);
+  });
+
+  afterEach(function() {
+    mpin.request.restore();
+    mpin.restore();
+  });
+
+  it("should return false as ActivationCode. If forceActive is false on RPA", function (done) {
+    var userId = "test@user.id";
+
+    stub.onCall(1).yields(null, eMpinTestData.mpin);//mpinId
+    mpin.init(function (err, data) {
+      mpin.makeNewUser(userId);
+      mpin.startRegistration(userId, function (err1, data1) {
+        var activationCode = mpin.getActivationCodeAdhoc(userId);
+        expect(activationCode).to.equal(false);
+        done();
+      }, true);
+    });
+  });
+
+  it("should return valid Activation Code. If forceActive is true on RPA", function (done) {
+    var userId = "test@user.id";
+
+    stub.onCall(1).yields(null, eMpinTestData.mpinForceActivated);//mpinId
+    mpin.init(function (err, data) {
+      mpin.makeNewUser(userId);
+      mpin.startRegistration(userId, function (err1, data1) {
+        var activationCode = mpin.getActivationCodeAdhoc(userId);
+        expect(activationCode).to.not.equal(false);
+        done();
+      }, true);
+    });
+  });
+});
+
+describe("# eMpin confirmRegistration.", function () {
+  var mpin, spy;
+  before(function () {
+    mpin = new mpinjs({server: eMpinTestData.serverUrl});
+    sinon.stub(mpin, "getData", function () {
+      return eMpinTestLocalstorage;
+    });
+    sinon.stub(mpin, "storeData");
+  });
+
+  afterEach(function () {
+    mpin.restore();
+    mpin.request.restore && mpin.request.restore();
+  });
+
+  it("should return error type " + eMpinErrors.timeoutFinish + " if server return 408 status code", function (done) {
+    var userId = "test@user.id", stub;
+
+    stub = sinon.stub(mpin, 'request');
+    stub.onCall(0).yields(null, eMpinTestData.clientSettings);
+    stub.onCall(1).yields(null, eMpinTestData.mpin);//mpinId
+    stub.onCall(2).yields({status: 408}); // timeout code
+
+    mpin.init(function (err, data) {
+      mpin.makeNewUser(userId);
+      mpin.startRegistration(userId, function (err1, data1) {
+        mpin.confirmRegistration(userId, function (err2, data2) {
+          expect(err2).to.deep.equal({code: 8, type: eMpinErrors.timeoutFinish});
+          done();
+        }, true);
+      }, true);
+    });
+  });
+
+  it("should return error type " + eMpinErrors.wrongFlow + " if server return no client secret", function (done) {
+    var userId = "test@user.id", stub;
+
+    stub = sinon.stub(mpin, 'request');
+    stub.onCall(0).yields(null, eMpinTestData.clientSettings);
+    stub.onCall(1).yields(null, eMpinTestData.mpin);//mpinId
+    stub.onCall(2).yields(null, eMpinTestData.csError); // timeout code
+
+    mpin.init(function (err, data) {
+      mpin.makeNewUser(userId);
+      mpin.startRegistration(userId, function (err1, data1) {
+        mpin.confirmRegistration(userId, function (err2, data2) {
+          expect(err2).to.deep.equal({code: 6, type: eMpinErrors.wrongFlow});
+          done();
+        }, true);
+      }, true);
+    });
+  });
+
+  it("should return OK", function (done) {
+    var userId = "test@user.id", stub;
+
+    stub = sinon.stub(mpin, 'request');
+    stub.onCall(0).yields(null, eMpinTestData.clientSettings);
+    stub.onCall(1).yields(null, eMpinTestData.mpin);//mpinId
+    stub.onCall(2).yields(null, eMpinTestData.cs);//cs1
+
+    oneStepSpy = sinon.spy(mpin, "getClientSecretOneStep");
+    twoStepSpy = sinon.spy(mpin, "getClientSecretTwoStep");
+
+    mpin.init(function (err, data) {
+      mpin.makeNewUser(userId);
+      mpin.startRegistration(userId, function (err1, data1) {
+        mpin.confirmRegistration(userId, function (err2, data2) {
+          expect(data2).to.exist;
+          expect(oneStepSpy.callCount).to.equal(1);
+          expect(twoStepSpy.callCount).to.equal(0);
+          done();
+        }, true);
+      }, true);
+    });
+  });
+});
+
+
+describe("# eMpin activationCodeVerify.", function () {
+  var mpin;
+  before(function () {
+    mpin = new mpinjs({server: eMpinTestData.serverUrl});
+    sinon.stub(mpin, "getData", function () {
+      return eMpinTestLocalstorage;
+    });
+    sinon.stub(mpin, "storeData");
+  });
+
+  afterEach(function () {
+    mpin.restore();
+    mpin.request.restore && mpin.request.restore();
+  });
+
+  it("should return error type " + eMpinErrors.missingUserId + ", call without userId", function (done) {
+    var userId = "test@user.id", stub;
+
+    stub = sinon.stub(mpin, 'request');
+    stub.onCall(0).yields(null, eMpinTestData.clientSettings);
+    stub.onCall(1).yields(null, eMpinTestData.mpin);
+    stub.onCall(2).yields(null, eMpinTestData.cs);
+    stub.onCall(3).yields(null, eMpinTestData.verify);
+
+    mpin.init(function (err, data) {
+      mpin.makeNewUser(userId);
+      mpin.startRegistration(userId, function (err1, data1) {
+        mpin.confirmRegistration(userId, function (err2, data2) {
+          mpin.activationCodeVerify(null, eMpinTestData.activationCode, function (err3, data3) {
+            expect(err3).to.deep.equal({code: 0, type: eMpinErrors.missingUserId});
+            done();
+          });
+        }, true);
+      }, true);
+    });
+
+  });
+
+  it("should return error type " + eMpinErrors.missingActivationCode + ", call without activation code", function (done) {
+    var userId = "test@user.id", stub;
+
+    stub = sinon.stub(mpin, 'request');
+    stub.onCall(0).yields(null, eMpinTestData.clientSettings);
+    stub.onCall(1).yields(null, eMpinTestData.mpin);
+    stub.onCall(2).yields(null, eMpinTestData.cs);
+    stub.onCall(3).yields(null, eMpinTestData.verify);
+
+    mpin.init(function (err, data) {
+      mpin.makeNewUser(userId);
+      mpin.startRegistration(userId, function (err1, data1) {
+        mpin.confirmRegistration(userId, function (err2, data2) {
+          mpin.activationCodeVerify(userId, null, function (err3, data3) {
+            expect(err3).to.deep.equal({code: 12, type: eMpinErrors.missingActivationCode});
+            done();
+          });
+        }, true);
+      }, true);
+    });
+  });
+
+  it("should return error type " + eMpinErrors.invalidActivationCode + ", if server returns 403 status code", function (done) {
+    var userId = "test@user.id", stub;
+
+    stub = sinon.stub(mpin, 'request');
+    stub.onCall(0).yields(null, eMpinTestData.clientSettings);
+    stub.onCall(1).yields(null, eMpinTestData.mpin);
+    stub.onCall(2).yields(null, eMpinTestData.cs);
+    stub.onCall(3).yields({status: 403});
+
+    mpin.init(function (err, data) {
+      mpin.makeNewUser(userId);
+      mpin.startRegistration(userId, function (err1, data1) {
+        mpin.confirmRegistration(userId, function (err2, data2) {
+          mpin.activationCodeVerify(userId, eMpinTestData.activationCode, function (err3, data3) {
+            expect(err3).to.deep.equal({code: 13, type: eMpinErrors.invalidActivationCode});
+            done();
+          });
+        }, true);
+      }, true);
+    });
+  });
+
+  it("should return error type " + eMpinErrors.maxAttemptsCountOver + ", if server returns 410 status code", function (done) {
+    var userId = "test@user.id", stub;
+
+    stub = sinon.stub(mpin, 'request');
+    stub.onCall(0).yields(null, eMpinTestData.clientSettings);
+    stub.onCall(1).yields(null, eMpinTestData.mpin);
+    stub.onCall(2).yields(null, eMpinTestData.cs);
+    stub.onCall(3).yields({status: 410});
+
+    mpin.init(function (err, data) {
+      mpin.makeNewUser(userId);
+      mpin.startRegistration(userId, function (err1, data1) {
+        mpin.confirmRegistration(userId, function (err2, data2) {
+          mpin.activationCodeVerify(userId, eMpinTestData.activationCode, function (err3, data3) {
+            expect(err3).to.deep.equal({code: 14, type: eMpinErrors.maxAttemptsCountOver});
+            done();
+          });
+        }, true);
+      }, true);
+    });
+  });
+
+
+  it("should return OK", function (done) {
+    var userId = "test@user.id", stub;
+
+    stub = sinon.stub(mpin, 'request');
+    stub.onCall(0).yields(null, eMpinTestData.clientSettings);
+    stub.onCall(1).yields(null, eMpinTestData.mpin);
+    stub.onCall(2).yields(null, eMpinTestData.cs);
+    stub.onCall(3).yields(null, eMpinTestData.verify);
+
+    mpin.init(function (err, data) {
+      mpin.makeNewUser(userId);
+      mpin.startRegistration(userId, function (err1, data1) {
+        mpin.confirmRegistration(userId, function (err2, data2) {
+          mpin.activationCodeVerify(userId, eMpinTestData.activationCode, function (err3, data3) {
+            expect(data3).to.exist;
+            done();
+          });
+        }, true);
+      }, true);
+    });
+  });
+});
+
+describe("# eMpin finishRegistration", function () {
+  var mpin, spy, userId = "test@user.id";
+
+  beforeEach(function () {
+    mpin = new mpinjs({server: eMpinTestData.serverUrl});
+
+    sinon.stub(mpin, "getData", function () {
+      return eMpinTestLocalstorage;
+    });
+
+    sinon.stub(mpin, "storeData");
+  });
+
+  afterEach(function () {
+    mpin.restore();
+    mpin.request.restore && mpin.request.restore();
+  });
+
+  it("should save user", function (done) {
+    var userPin = "userSecret";
+
+    stub = sinon.stub(mpin, 'request');
+    stub.onCall(0).yields(null, eMpinTestData.clientSettings);
+    stub.onCall(1).yields(null, eMpinTestData.mpin);
+    stub.onCall(2).yields(null, eMpinTestData.cs);
+    stub.onCall(3).yields(null, eMpinTestData.verify);
+
+    mpin.init(function (err, data) {
+      mpin.makeNewUser(userId);
+      mpin.startRegistration(userId, function (err1, data1) {
+        mpin.confirmRegistration(userId, function (err2, data2) {
+          mpin.activationCodeVerify(userId, eMpinTestData.activationCode, function (err3, data3) {
+            spy = sinon.spy(mpin, "addToUser");
+            var data4 = mpin.finishRegistration(userId, userPin, eMpinTestData.activationCode, true);
+            expect(data4).to.exist;
+            expect(spy.calledOnce).to.be.true;
+            done();
+          });
+        }, true);
+      }, true);
+    });
+  });
+});
+
+describe("# eMpin finishAuthentication", function () {
+  var mpin, spy, userId = "test@user.id", userPin = "userPIN";
+
+  beforeEach(function (done) {
+    mpin = new mpinjs({server: eMpinTestData.serverUrl});
+    sinon.stub(mpin, "getData", function () {
+      return eMpinTestLocalstorage;
+    });
+    sinon.stub(mpin, "storeData");
+    stub = sinon.stub(mpin, 'request');
+    stub.onCall(0).yields(null, eMpinTestData.clientSettings);
+    stub.onCall(1).yields(null, eMpinTestData.mpin);
+    stub.onCall(2).yields(null, eMpinTestData.cs);
+    stub.onCall(3).yields(null, eMpinTestData.verify);
+
+    this.setupFlow = function (cb) {
+      mpin.init(function (err, data) {
+        mpin.makeNewUser(userId);
+        mpin.startRegistration(userId, function (err1, data1) {
+          mpin.confirmRegistration(userId, function (err2, data2) {
+            mpin.activationCodeVerify(userId, eMpinTestData.activationCode, function (err3, data3) {
+              mpin.finishRegistration(userId, userPin, eMpinTestData.activationCode, true);
+              cb();
+            });
+          }, true);
+        }, true);
+      });
+    };
+
+    done();
+  });
+
+  afterEach(function () {
+    mpin.restore();
+    mpin.request.restore && mpin.request.restore();
+  });
+
+
+  it("should use _eMpinPassRequests method", function (done) {
+    var authOut = null;
+    stub.onCall(4).yields(null, eMpinTestData.tp1);//tp1
+    stub.onCall(5).yields({status: 404}, null);//timePermitStorage
+    stub.onCall(6).yields(null, eMpinTestData.tp2); //tp2
+    stub.onCall(7).yields(null, eMpinTestData.auth); //pass
+
+    eMpinPassReqSpy = sinon.spy(mpin, "_eMpinPassRequests");
+    passReqSpy = sinon.spy(mpin, "_passRequests");
+
+    this.setupFlow(function () {
+      mpin.startAuthentication(userId, function (err, data) {
+        mpin.finishAuthentication(userId, "test", function (err2, data2) {
+          expect(eMpinPassReqSpy.callCount).to.equal(1);
+          expect(passReqSpy.callCount).to.equal(0);
+          done();
+        }, true);
+      });
+    });
+  });
+});

--- a/test/empin_inits.js
+++ b/test/empin_inits.js
@@ -1,0 +1,187 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+//if browser
+var empin_inits = function () {
+  var Errors, MPINAuth, MPIN, testData, testLocalStorage, testLocalStorage2;
+
+  Errors = [];
+  Errors.missingUserId = "MISSING_USERID";
+  Errors.invalidUserId = "INVALID_USERID";
+  Errors.missingParams = "MISSING_PARAMETERS";
+  Errors.identityNotVerified = "IDENTITY_NOT_VERIFIED";
+  Errors.identityMissing = "IDENTITY_MISSING";
+  Errors.wrongPin = "WRONG_PIN";
+  Errors.wrongFlow = "WRONG_FLOW";
+  Errors.userRevoked = "USER_REVOKED";
+  Errors.timeoutFinish = "TIMEOUT_FINISH";
+  Errors.missingActivationCode = "MISSING_ACTIVATION_CODE";
+  Errors.invalidActivationCode = "INVALID_ACTIVATION_CODE";
+  Errors.maxAttemptsCountOver = "MAX_ATTEMPTS_COUNT_OVER";
+
+  //overwrite global crypto function
+  MPINAuth = {};
+  MPINAuth.addShares = function () {
+    return "040a23a7e6d381a6dbd8b806013f07d40be36b42723ad3b1d986e4bbbe9ece83f421c504a4258cf87251af4ea7e847e4da46730034fc880f92d885c419716cb944";
+  };
+  MPINAuth.calculateMPinToken = function () {
+    return "04236eb28be98764e379049a2c4371752e7e3adc99a844800b9de2c34d2c70d95b07354c556276cbf79cee9e601807e6166d9bffedc3c1b1909ab5bf63330e2131";
+  };
+  MPINAuth.pass1Request = function () {
+    return {};
+  };
+  MPINAuth.pass2Request = function () {
+    return {};
+  };
+
+  eMpinAuth = {};
+  eMpinAuth.activationCheck = function() {
+    return {
+      MpinId: "7b226d6f62696c65223a20302c2022697373756564223a2022323031362d30352d31312031373a35333a35382e333138383232222c2022757365724944223a20227465737440757365722e6964222c202273616c74223a20223934633531353366616435353236316666656231653239626164396439336536227d",
+      U: "0410088291e8b416bb42459812545adb49559d87b5bcbe925d2c4c5ae6c0c76d9a1c9d2d4893de63a370899ddcf2be8ef514cbd8b869fcfb5a1e7970a6555f1967",
+      V: "040d5462cea71a0e894690a1c339962e8ff57b3e0f379375d89b29cfeafe53fe641d74e570817d135ca5c150267bbb1e38ab6486951a0aa392f745bf7ded212ef8"
+    };
+  };
+  eMpinAuth.calcClientSecretWithActivationCode = function() {
+    return "04203ddb03ff81d0ee3a69922b71e33937eb106c912faf4d4b08728a4100274fab00623906abbcb73d5ab1e4d50e65046af29ed9c18ccad3bb30c0ccf935b03d7b";
+  };
+  eMpinAuth.authenticate = function() {
+    return {
+      userId: "test@user.id",
+      client_curren_time: "154a1301528",
+      tokenHex: "0419a1678856dcaa871a2fdabeba9920c04c6c7c4abc57cb8a0bff9d279227b00118c9c56fd10ac84a817fa3a1f52d2200eeebd84ac76538b5a8effdbf514d5798"
+    }
+  };
+  eMpinAuth.calcClientSecretWithStringPin = function() {
+    return '0419a1678856dcaa871a2fdabeba9920c04c6c7c4abc57cb8a0bff9d279227b00118c9c56fd10ac84a817fa3a1f52d2200eeebd84ac76538b5a8effdbf514d5798';
+  };
+  eMpinAuth.getTime = function() {
+    return Date.now();
+  };
+
+  MPIN = {};
+  MPIN.stringtobytes = function () {
+    return "";
+  }
+  MPIN.HASH_ID = function () {
+    return "";
+  }
+  MPIN.bytestostring = function () {
+    return "";
+  }
+
+  testData = {};
+  testData.serverUrl = "http://192.168.10.63:8005";
+  testData.clientSettings = {
+    requestOTP: false,
+    mpinAuthServerURL: "http://192.168.10.63:8011/rps",
+    registerURL: "http://192.168.10.63:8011/rps/user",
+    signatureURL: "http://192.168.10.63:8011/rps/signature",
+    certivoxURL: "https://community-api.certivox.net/v3/",
+    timePermitsURL: "http://192.168.10.63:8011/rps/timePermit"
+  };
+  testData.mpin = {
+    mpinId: "7b226d6f62696c65223a20302c2022697373756564223a2022323031362d30352d31312031373a34373a31372e323730373137222c2022757365724944223a20227465737440757365722e6964222c202273616c74223a20223563646431393762343434363831323638613838393332613932383833363139227d",
+    active: false,
+    activationCode: "0",
+    clientSecretShare: "041cbe23fdf4d89c50682271821653295639aac354eceb895a02158da0733c66a723e46c9d38db19f8b8316d70be6b5df0339cd9802c5565293908ca50354dd48b",
+    params: "mobile=0&expires=2016-05-11T18%3A47%3A17Z&app_id=d38e50460aa611e6b23b06df5546c0ed&hash_mpin_id=ee98736646a337ca53d176d317bd076bac01927595c76491aa8acb129871297c&signature=5bfdef889c353188236e4d2a637217098a98087d6527a6674eefe3dc157a9434&hash_user_id="
+  };
+  testData.mpinForceActivated = {
+    mpinId: "7b226d6f62696c65223a20302c2022697373756564223a2022323031362d30352d31312031373a34373a31372e323730373137222c2022757365724944223a20227465737440757365722e6964222c202273616c74223a20223563646431393762343434363831323638613838393332613932383833363139227d",
+    active: true,
+    activationCode: "932823342445",
+    clientSecretShare: "041cbe23fdf4d89c50682271821653295639aac354eceb895a02158da0733c66a723e46c9d38db19f8b8316d70be6b5df0339cd9802c5565293908ca50354dd48b",
+    params: "mobile=0&expires=2016-05-11T18%3A47%3A17Z&app_id=d38e50460aa611e6b23b06df5546c0ed&hash_mpin_id=ee98736646a337ca53d176d317bd076bac01927595c76491aa8acb129871297c&signature=5bfdef889c353188236e4d2a637217098a98087d6527a6674eefe3dc157a9434&hash_user_id="
+  };
+  testData.activationCode = 932823342445;
+
+  testData.cs = {
+    clientSecret: "04023f8968bc12ca0c7666ec8563f80d5e55389e724442bf1a1dd36bab518b9155210bc72d4fe20e086d2de7c7bfdad2d17a166185de3994a76fa224974377c203",
+    message: "OK",
+    version: "3"
+  };
+
+  testData.csError = {
+    message: "OK",
+    version: "3"
+  };
+
+  testData.verify = {
+    message: "eMpin Activation is valid.",
+    result: true,
+    version: "3"
+  };
+  testData.tp1 = {
+    "timePermit": "04145085669aa20607c0da730c01c707010e546bb81cf17abc29cacfef8e162b0f097b547c7058f6bd88e55cadc721b5721ee9730bfb10fa239c5bfacdb62fa3f4",
+    "signature": "39f9e16201d05dd3e369d43bd73cf0249e5bac01d5ff2975640d988e4a37b7f5",
+    "date": 16876
+  };
+  testData.tp2 = {
+    "timePermit": "040ff870574cb3c923410fdf33681beacd6ca6eeeb8858150efbf1241da9202c5604977ae285410df0d86a9976611b255a6fcbeeaf22bb398e4859ff3348bb4d87"
+  };
+  testData.auth = {
+    "authOTT": "b0784ab9b6759953a3c6da85bdbdbaf3"
+  };
+
+  testLocalStorage = {
+    "accounts": {
+      "7b226d6f62696c65223a20302c2022697373756564223a2022323031362d30322d32332031363a34393a31302e313039363734222c2022757365724944223a20227465737440746573742e636f6d222c202273616c74223a20223162396336353564343665323238373661333631373033353138616636363037227d": {
+        "regOTT": "4ac1cca55c09f6d4e47a253d8cd503b5",
+        "state": "STARTED"
+      }
+    }
+  };
+
+  testLocalStorage2 = {
+    "defaultIdentity": "7b226d6f62696c65223a20302c2022697373756564223a2022323031362d30322d30332031363a31333a32362e333030393938222c2022757365724944223a2022616161406262622e636f6d222c202273616c74223a20223237386166373433663465373034363764323334313936323262316333616231227d",
+    "version": "0.3",
+    "accounts": {
+      "7b226d6f62696c65223a20302c2022697373756564223a2022323031362d30322d30332031363a31333a32362e333030393938222c2022757365724944223a2022616161406262622e636f6d222c202273616c74223a20223237386166373433663465373034363764323334313936323262316333616231227d": {
+        "MPinPermit": "",
+        "token": "",
+        "regOTT": "b6216da7e3224e07eb4791815bcfcaa6"
+      },
+      "7b226d6f62696c65223a20302c2022697373756564223a2022323031362d30322d30382030383a35383a34302e373737373130222c2022757365724944223a2022646464737265406d61696c696e61746f722e636f6d222c202273616c74223a20223831373539623463313032363666646431616337323231326530643839393932227d": {
+        "MPinPermit": "042235a80c4c24f25a8a61758d3dac87d72b693c989ef95704c2ba51c7f4d98a631c912c9dc48435d9dd1af3dc17fa7d9e2af9beb16cc77bd38150c4697efdf232",
+        "token": "0412e48b124199f683e0ea6b8a1f1b073013dce21610de4b54cac74696e02003b1147d3ad7b4cef542c6ef61726dc4ffba039c90f7edd17cbeafb7c0737b41fc82",
+        "regOTT": "11adb574045ffe27e718d8b4dc665887",
+        "timePermitCache": {
+          "date": 16867,
+          "timePermit": "041c990c4087b5eeb7f4c2dbe5869794c208a22f63f6485a8905b35f542b2136a91cccf0696a6c60b2208ff1d3178da8fa661f7a52dda7db2738bfb1fe8b6cfa4b"
+        }
+      }
+    },
+    "deviceName": "winChrome"
+  };
+
+  return {
+    Errors: Errors,
+    MPINAuth: MPINAuth,
+    MPIN: MPIN,
+    testData: testData,
+    testLocalStorage: testLocalStorage,
+    testLocalStorage2: testLocalStorage2
+  };
+}();
+
+if (typeof module !== 'undefined' && typeof module.exports !== 'undefined')
+  module.exports = empin_inits;
+else
+  window.empin_inits = empin_inits;

--- a/test/index.html
+++ b/test/index.html
@@ -32,9 +32,11 @@ and open the template in the editor.
 
 		</script>
 
-		<script src="init.js"></script>
-		<script src="index.js"></script>
-		<script src="auth.js"></script>
+    <script src="init.js"></script>
+    <script src="index.js"></script>
+    <script src="auth.js"></script>
+    <script src="empin_inits.js"></script>
+    <script src="empin.js"></script>
 		<script>
 
       mocha.run();


### PR DESCRIPTION
** AVAILABLE eMpin authentication program (1-pass Mpin Authentication with ldap-proxy)
This is the part of the eMpin authentication (1-pass Mpin Authentication with ldap-proxy) program.
For using the eMpin auth., our program is merged to
- milagro-crpyto: cryptographic library 
- milagro-mfa-js-lib: client-side program (This PR)
(- miragro-mfa-server: server-side program)
And the following repositories are the new ones for using the eMpin auth.,
- milagro-mfa-onepass-client: client GUI program
- ldap-proxy: switching ID/PASS or eMpin Auth
